### PR TITLE
feat: Add dynamic compilation of postgres hash to support any version

### DIFF
--- a/src/Respawn.Postgres/PostgresHelper.cs
+++ b/src/Respawn.Postgres/PostgresHelper.cs
@@ -133,8 +133,6 @@ namespace Respawn.Postgres
                 }
             }
 
-            Debug.Assert(columns.Count == 136, "Not all columns were read!");
-
             return columns;
         }
 

--- a/src/Respawn.Postgres/PostgresHelper.cs
+++ b/src/Respawn.Postgres/PostgresHelper.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Npgsql;
 
 namespace Respawn.Postgres
@@ -7,6 +10,16 @@ namespace Respawn.Postgres
     internal static class PostgresHelper
     {
         private const string PostgresSystemDatabase = "postgres";
+
+        static readonly IReadOnlyDictionary<string, string> _columnQueryOrder = new Dictionary<string, string>
+        {
+            {"n", "pg_namespace"},
+            {"f", "pg_attribute"},
+            {"p", "pg_constraint"},
+            {"g", "pg_class"},
+            {"c", "pg_class"},
+            {"t", "pg_type"},
+        };
 
         internal static string ExtractDatabaseName(string connectionString)
         {
@@ -84,6 +97,47 @@ namespace Respawn.Postgres
             }
         }
 
+        static List<DatabaseColumn> GetDatabaseColumns(NpgsqlCommand command)
+        {
+            command.CommandText = @"
+                select 
+	                t.table_name,
+	                c.column_name
+                from information_schema.tables t
+                left join information_schema.columns c 
+	                on t.table_schema = c.table_schema 
+	                and t.table_name = c.table_name
+                where (table_type = 'VIEW' and t.table_name = 'columns')
+                or t.table_type = 'BASE TABLE' and t.table_name in (
+	                'pg_class',
+	                'pg_type',
+	                'pg_attrdef',
+	                'pg_namespace',
+	                'pg_constraint'
+                );
+            ";
+
+            var columns = new List<DatabaseColumn>();
+            using (var reader = command.ExecuteReader())
+            {
+                if (reader.HasRows)
+                {
+                    while (reader.Read())
+                    {
+                        columns.Add(new DatabaseColumn
+                        {
+                            TableName = reader.GetString(0),
+                            ColumnName = reader.GetString(1)
+                        });
+                    }
+                }
+            }
+
+            Debug.Assert(columns.Count == 136, "Not all columns were read!");
+
+            return columns;
+        }
+
         internal static decimal GetDatabaseStructureHash(string connectionString, int? commandTimeout = null)
         {
             using (var connection = new NpgsqlConnection(connectionString))
@@ -97,165 +151,46 @@ namespace Respawn.Postgres
                         command.CommandTimeout = commandTimeout.Value;
                     }
 
-                    command.CommandText = @"
-                        SELECT SUM(('x' || md5(
-                                 coalesce(n.nspname, '') ||
-                          ' ' || coalesce(n.nspowner::text, '') ||
-                          ' ' || coalesce(n.nspacl::text, '') ||
-                          ' ' || coalesce(f.attrelid::text, '') ||
-                          ' ' || coalesce(f.attname, '') ||
-                          ' ' || coalesce(f.atttypid::text, '') ||
-                          ' ' || coalesce(f.attstattarget::text, '') ||
-                          ' ' || coalesce(f.attlen::text, '') ||
-                          ' ' || coalesce(f.attnum::text, '') ||
-                          ' ' || coalesce(f.attndims::text, '') ||
-                          ' ' || coalesce(f.attcacheoff::text, '') ||
-                          ' ' || coalesce(f.atttypmod::text, '') ||
-                          ' ' || coalesce(f.attbyval::text, '') ||
-                          ' ' || coalesce(f.attstorage, '') ||
-                          ' ' || coalesce(f.attalign, '') ||
-                          ' ' || coalesce(f.attnotnull::text, '') ||
-                          ' ' || coalesce(f.atthasdef::text, '') ||
-                          ' ' || coalesce(f.attidentity, '') ||
-                          ' ' || coalesce(f.attisdropped::text, '') ||
-                          ' ' || coalesce(f.attislocal::text, '') ||
-                          ' ' || coalesce(f.attinhcount::text, '') ||
-                          ' ' || coalesce(f.attcollation::text, '') ||
-                          ' ' || coalesce(f.attacl::text, '') ||
-                          ' ' || coalesce(f.attoptions::text, '') ||
-                          ' ' || coalesce(f.attfdwoptions::text, '') ||
-                          ' ' || coalesce(p.conname, '') ||
-                          ' ' || coalesce(p.connamespace::text, '') ||
-                          ' ' || coalesce(p.contype, '') ||
-                          ' ' || coalesce(p.condeferrable::text, '') ||
-                          ' ' || coalesce(p.condeferred::text, '') ||
-                          ' ' || coalesce(p.convalidated::text, '') ||
-                          ' ' || coalesce(p.conrelid::text, '') ||
-                          ' ' || coalesce(p.contypid::text, '') ||
-                          ' ' || coalesce(p.conindid::text, '') ||
-                          ' ' || coalesce(p.confrelid::text, '') ||
-                          ' ' || coalesce(p.confupdtype, '') ||
-                          ' ' || coalesce(p.confdeltype, '') ||
-                          ' ' || coalesce(p.confmatchtype, '') ||
-                          ' ' || coalesce(p.conislocal::text, '') ||
-                          ' ' || coalesce(p.coninhcount::text, '') ||
-                          ' ' || coalesce(p.connoinherit::text, '') ||
-                          ' ' || coalesce(p.conkey::text, '') ||
-                          ' ' || coalesce(p.confkey::text, '') ||
-                          ' ' || coalesce(p.conpfeqop::text, '') ||
-                          ' ' || coalesce(p.conppeqop::text, '') ||
-                          ' ' || coalesce(p.conffeqop::text, '') ||
-                          ' ' || coalesce(p.conexclop::text, '') ||
-                          ' ' || coalesce(p.conbin::text, '') ||
-                          ' ' || coalesce(p.consrc, '') ||
-                          ' ' || coalesce(g.relname, '') ||
-                          ' ' || coalesce(g.relnamespace::text, '') ||
-                          ' ' || coalesce(g.reltype::text, '') ||
-                          ' ' || coalesce(g.reloftype::text, '') ||
-                          ' ' || coalesce(g.relowner::text, '') ||
-                          ' ' || coalesce(g.relam::text, '') ||
-                          ' ' || coalesce(g.relfilenode::text, '') ||
-                          ' ' || coalesce(g.reltablespace::text, '') ||
-                          ' ' || coalesce(g.relpages::text, '') ||
-                          ' ' || coalesce(g.reltuples::text, '') ||
-                          ' ' || coalesce(g.relallvisible::text, '') ||
-                          ' ' || coalesce(g.reltoastrelid::text, '') ||
-                          ' ' || coalesce(g.relhasindex::text, '') ||
-                          ' ' || coalesce(g.relisshared::text, '') ||
-                          ' ' || coalesce(g.relpersistence, '') ||
-                          ' ' || coalesce(g.relkind, '') ||
-                          ' ' || coalesce(g.relnatts::text, '') ||
-                          ' ' || coalesce(g.relchecks::text, '') ||
-                          ' ' || coalesce(g.relhasoids::text, '') ||
-                          ' ' || coalesce(g.relhasrules::text, '') ||
-                          ' ' || coalesce(g.relhastriggers::text, '') ||
-                          ' ' || coalesce(g.relhassubclass::text, '') ||
-                          ' ' || coalesce(g.relrowsecurity::text, '') ||
-                          ' ' || coalesce(g.relforcerowsecurity::text, '') ||
-                          ' ' || coalesce(g.relispopulated::text, '') ||
-                          ' ' || coalesce(g.relreplident, '') ||
-                          ' ' || coalesce(g.relispartition::text, '') ||
-                          ' ' || coalesce(g.relfrozenxid::text, '') ||
-                          ' ' || coalesce(g.relminmxid::text, '') ||
-                          ' ' || coalesce(g.relacl::text, '') ||
-                          ' ' || coalesce(g.reloptions::text, '') ||
-                          ' ' || coalesce(g.relpartbound::text, '') ||
-                          ' ' || coalesce(n.nspname, '') ||
-                          ' ' || coalesce(n.nspowner::text, '') ||
-                          ' ' || coalesce(n.nspacl::text, '') ||
-                          ' ' || coalesce(c.relname, '') ||
-                          ' ' || coalesce(c.relnamespace::text, '') ||
-                          ' ' || coalesce(c.reltype::text, '') ||
-                          ' ' || coalesce(c.reloftype::text, '') ||
-                          ' ' || coalesce(c.relowner::text, '') ||
-                          ' ' || coalesce(c.relam::text, '') ||
-                          ' ' || coalesce(c.relfilenode::text, '') ||
-                          ' ' || coalesce(c.reltablespace::text, '') ||
-                          ' ' || coalesce(c.relpages::text, '') ||
-                          ' ' || coalesce(c.reltuples::text, '') ||
-                          ' ' || coalesce(c.relallvisible::text, '') ||
-                          ' ' || coalesce(c.reltoastrelid::text, '') ||
-                          ' ' || coalesce(c.relhasindex::text, '') ||
-                          ' ' || coalesce(c.relisshared::text, '') ||
-                          ' ' || coalesce(c.relpersistence, '') ||
-                          ' ' || coalesce(c.relkind, '') ||
-                          ' ' || coalesce(c.relnatts::text, '') ||
-                          ' ' || coalesce(c.relchecks::text, '') ||
-                          ' ' || coalesce(c.relhasoids::text, '') ||
-                          ' ' || coalesce(c.relhasrules::text, '') ||
-                          ' ' || coalesce(c.relhastriggers::text, '') ||
-                          ' ' || coalesce(c.relhassubclass::text, '') ||
-                          ' ' || coalesce(c.relrowsecurity::text, '') ||
-                          ' ' || coalesce(c.relforcerowsecurity::text, '') ||
-                          ' ' || coalesce(c.relispopulated::text, '') ||
-                          ' ' || coalesce(c.relreplident, '') ||
-                          ' ' || coalesce(c.relispartition::text, '') ||
-                          ' ' || coalesce(c.relfrozenxid::text, '') ||
-                          ' ' || coalesce(c.relminmxid::text, '') ||
-                          ' ' || coalesce(c.relacl::text, '') ||
-                          ' ' || coalesce(c.reloptions::text, '') ||
-                          ' ' || coalesce(c.relpartbound::text, '') ||
-                          ' ' || coalesce(t.typname, '') ||
-                          ' ' || coalesce(t.typnamespace::text, '') ||
-                          ' ' || coalesce(t.typowner::text, '') ||
-                          ' ' || coalesce(t.typlen::text, '') ||
-                          ' ' || coalesce(t.typbyval::text, '') ||
-                          ' ' || coalesce(t.typtype, '') ||
-                          ' ' || coalesce(t.typcategory, '') ||
-                          ' ' || coalesce(t.typispreferred::text, '') ||
-                          ' ' || coalesce(t.typisdefined::text, '') ||
-                          ' ' || coalesce(t.typdelim, '') ||
-                          ' ' || coalesce(t.typrelid::text, '') ||
-                          ' ' || coalesce(t.typarray::text, '') ||
-                          ' ' || coalesce(t.typinput::text, '') ||
-                          ' ' || coalesce(t.typoutput::text, '') ||
-                          ' ' || coalesce(t.typreceive::text, '') ||
-                          ' ' || coalesce(t.typsend::text, '') ||
-                          ' ' || coalesce(t.typmodin::text, '') ||
-                          ' ' || coalesce(t.typmodout::text, '') ||
-                          ' ' || coalesce(t.typanalyze::text, '') ||
-                          ' ' || coalesce(t.typalign, '') ||
-                          ' ' || coalesce(t.typstorage, '') ||
-                          ' ' || coalesce(t.typnotnull::text, '') ||
-                          ' ' || coalesce(t.typbasetype::text, '') ||
-                          ' ' || coalesce(t.typtypmod::text, '') ||
-                          ' ' || coalesce(t.typndims::text, '') ||
-                          ' ' || coalesce(t.typcollation::text, '') ||
-                          ' ' || coalesce(t.typdefaultbin::text, '') ||
-                          ' ' || coalesce(t.typdefault, '') ||
-                          ' ' || coalesce(t.typacl::text, '') ||
-                          ' ' || coalesce(d.adrelid::text, '') ||
-                          ' ' || coalesce(d.adnum::text, '') ||
-                          ' ' || coalesce(d.adbin::text, '') ||
-                          ' ' || coalesce(d.adsrc, '')
-                          ))::bit(64)::bigint)
-                        FROM pg_attribute f  
-                            JOIN pg_class c ON c.oid = f.attrelid  
-                            JOIN pg_type t ON t.oid = f.atttypid  
-                            LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = f.attnum  
-                            LEFT JOIN pg_namespace n ON n.oid = c.relnamespace  
-                            LEFT JOIN pg_constraint p ON p.conrelid = c.oid AND f.attnum = ANY (p.conkey)  
-                            LEFT JOIN pg_class AS g ON p.confrelid = g.oid;";
+                    var columns = GetDatabaseColumns(command);
+
+                    var builder = new StringBuilder();
+                    builder.AppendLine("SELECT SUM(('x' || md5(");
+
+                    // We use a fixed order for types and then sort their columns by name
+                    // to ensure consistency between queries
+
+                    var first = true;
+                    foreach (var item in _columnQueryOrder)
+                    {
+                        var sorted = columns.Where(x => item.Value.Equals(x.TableName, StringComparison.OrdinalIgnoreCase))
+                            .OrderBy(x => x.ColumnName)
+                            .ToList();
+
+                        foreach (var column in sorted)
+                        {
+                            if (first)
+                            {
+                                builder.AppendFormat("\n\t\tcoalesce({0}.{1}::text, '')", item.Key, column.ColumnName);
+                                first = false;
+                            }
+                            else
+                            {
+                                builder.AppendFormat("\n\t\t|| ' ' || coalesce({0}.{1}::text, '')", item.Key, column.ColumnName);
+                            }
+                        }
+                    }
+
+                    builder.AppendLine(@"
+    ))::bit(64)::bigint)
+FROM pg_attribute f
+JOIN pg_class c ON c.oid = f.attrelid
+JOIN pg_type t ON t.oid = f.atttypid
+LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = f.attnum  
+LEFT JOIN pg_namespace n ON n.oid = c.relnamespace  
+LEFT JOIN pg_constraint p ON p.conrelid = c.oid AND f.attnum = ANY (p.conkey)  
+LEFT JOIN pg_class AS g ON p.confrelid = g.oid;");
+
+                    command.CommandText = builder.ToString();
 
                     return (decimal)(command.ExecuteScalar() ?? throw new InvalidOperationException("Could not determine database structure hash."));
                 }
@@ -369,14 +304,20 @@ namespace Respawn.Postgres
                 }
 
                 command.CommandText = $"select exists (select 1 from pg_database where datname='{databaseName}')";
+                // ReSharper disable once PossibleNullReferenceException
                 var result = (bool)command.ExecuteScalar();
-
                 if (result)
                 {
                     command.CommandText = $"drop database \"{databaseName}\"";
                     command.ExecuteNonQuery();
                 }
             }
+        }
+
+        class DatabaseColumn
+        {
+            public string TableName { get; set; }
+            public string ColumnName { get; set; }
         }
     }
 }


### PR DESCRIPTION
@sandord as discussed in #1, this PR will dynamically pull all of the columns based on the following query. 

I have tested on `9.6` so far; I think more testing is required before this should be considered ready to merge. Ideally, the test suite is expanded to automatically test against all currently supported versions Postgres via alpine containers.

```sql
select 
	t.table_name as view_name,
	c.column_name
from information_schema.tables t
left join information_schema.columns c 
	on t.table_schema = c.table_schema 
	and t.table_name = c.table_name
where (table_type = 'VIEW' and t.table_name = 'columns')
or t.table_type = 'BASE TABLE' and t.table_name in (
	'pg_class',
	'pg_type',
	'pg_attrdef',
	'pg_namespace',
	'pg_constraint'
)
;
```

Closes #1